### PR TITLE
Adding Capture Alpha deployer address to whitelist

### DIFF
--- a/testnet-02/whitelist.txt
+++ b/testnet-02/whitelist.txt
@@ -43,3 +43,4 @@ akash1w3k6qpr4uz44py4z68chfrl7ltpxwtkngnc6xk # Scott Carrutehrs - July 5 2023
 akash10nys6kc6yu8d0rsznzc7lxrh9nv3vdm27q5uur # July 4 2023
 akash1vc3ncv776hevlurtcr9mkjarnvzpzknaw53d0c # July 5 2023
 akash1zzr2w5kuwcz8996te7rfg5rp3z7nlex7ngtgwx # July 5 2023
+akash1paac70etxcyglu8y73kqsg6ahsty9vkt5fmr6h # lambolam - July 6 2023


### PR DESCRIPTION
For Task 4 in testnet